### PR TITLE
Fixed `RelativeMotionEvent`-related compilation errors (for now)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ features = ["jsonc"]
 [dependencies.smithay]
 
 git      = "https://github.com/smithay/smithay.git"
+rev      = "0673cc13"
 features = ["desktop", "default", "backend_egl", "use_system_lib"]
 
 [dependencies.serde]

--- a/src/compositor/backend/udev.rs
+++ b/src/compositor/backend/udev.rs
@@ -43,7 +43,7 @@ use smithay::{
             element::{texture::TextureBuffer, AsRenderElements},
             gles2::{Gles2Renderbuffer, Gles2Renderer},
             multigpu::{egl::EglGlesBackend, GpuManager, MultiRenderer, MultiTexture},
-            Bind, Frame, ImportDma, Renderer, ImportEgl,
+            Bind, Frame, ImportDma, ImportEgl, Renderer,
         },
         session::{libseat::LibSeatSession, Event as SessionEvent, Session},
         udev::{all_gpus, primary_gpu, UdevBackend, UdevEvent},
@@ -92,7 +92,8 @@ use crate::compositor::{
 use super::Backend;
 
 type UdevRenderer<'a> = MultiRenderer<
-    'a, 'a,
+    'a,
+    'a,
     EglGlesBackend<Gles2Renderer>,
     EglGlesBackend<Gles2Renderer>,
     Gles2Renderbuffer,

--- a/src/compositor/focus.rs
+++ b/src/compositor/focus.rs
@@ -85,6 +85,19 @@ impl<BEnd: Backend> PointerTarget<Navda<BEnd>> for FocusTarget {
             FocusTarget::Popup(p) => PointerTarget::leave(p.wl_surface(), seat, data, serial, time),
         }
     }
+
+    fn relative_motion(
+        &self,
+        seat: &Seat<Navda<BEnd>>,
+        data: &mut Navda<BEnd>,
+        event: &pointer::RelativeMotionEvent,
+    ) {
+        match self {
+            Self::Window(l) => PointerTarget::relative_motion(l, seat, data, event),
+            Self::LayerSurface(l) => PointerTarget::relative_motion(l, seat, data, event),
+            Self::Popup(p) => PointerTarget::relative_motion(p.wl_surface(), seat, data, event),
+        }
+    }
 }
 
 impl<BEnd: Backend> KeyboardTarget<Navda<BEnd>> for FocusTarget {

--- a/src/compositor/mod.rs
+++ b/src/compositor/mod.rs
@@ -1,4 +1,4 @@
-use slog::{Logger, Drain, o};
+use slog::{o, Drain, Logger};
 
 use self::backend::run_udev;
 
@@ -14,10 +14,7 @@ mod state;
 
 pub fn start() -> Result<(), Box<dyn std::error::Error>> {
     let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-    let log = Logger::root(
-        slog_term::FullFormat::new(plain)
-        .build().fuse(), o!()
-    );
+    let log = Logger::root(slog_term::FullFormat::new(plain).build().fuse(), o!());
     run_udev(log);
     Ok(())
 }

--- a/src/compositor/shell/avwindow/mod.rs
+++ b/src/compositor/shell/avwindow/mod.rs
@@ -277,6 +277,21 @@ impl<BEnd: Backend> PointerTarget<Navda<BEnd>> for AvWindow {
             Self::X11(w) => PointerTarget::leave(w, seat, data, serial, time),
         }
     }
+
+    ///
+    /// https://wayland.app/protocols/relative-pointer-unstable-v1
+    ///
+    fn relative_motion(
+        &self,
+        seat: &Seat<Navda<BEnd>>,
+        data: &mut Navda<BEnd>,
+        event: &pointer::RelativeMotionEvent,
+    ) {
+        match self {
+            Self::Wayland(w) => PointerTarget::relative_motion(w, seat, data, event),
+            Self::X11(w) => PointerTarget::relative_motion(w, seat, data, event),
+        }
+    }
 }
 
 ///

--- a/src/compositor/shell/grabs/grab_move.rs
+++ b/src/compositor/shell/grabs/grab_move.rs
@@ -60,4 +60,19 @@ impl<BEnd: Backend> PointerGrab<Navda<BEnd>> for MoveSurfaceGrab<BEnd> {
     fn start_data(&self) -> &pointer::GrabStartData<Navda<BEnd>> {
         &self.start_data
     }
+
+    fn relative_motion(
+        &mut self,
+        data: &mut Navda<BEnd>,
+        handle: &mut pointer::PointerInnerHandle<'_, Navda<BEnd>>,
+        focus: Option<(
+            <Navda<BEnd> as SeatHandler>::PointerFocus,
+            Point<i32, Logical>,
+        )>,
+        event: &pointer::RelativeMotionEvent,
+    ) {
+        handle.relative_motion(data, focus, event);
+
+        // TODO(Sammy99jsp) possibly find another use for this.
+    }
 }

--- a/src/compositor/shell/mod.rs
+++ b/src/compositor/shell/mod.rs
@@ -31,7 +31,10 @@ use smithay::{
 pub use self::avwindow::{AvWindow, AvWindowRenderElement};
 use self::grabs::ResizeState;
 
-use super::{backend::Backend, state::Navda};
+use super::{
+    backend::Backend,
+    state::{CalloopData, Navda},
+};
 
 mod avwindow;
 mod grabs;
@@ -94,7 +97,7 @@ impl<BEnd: Backend> CompositorHandler for Navda<BEnd> {
         &mut self.compositor_state
     }
     fn commit(&mut self, surface: &WlSurface) {
-        X11Wm::commit_hook(surface);
+        X11Wm::commit_hook::<CalloopData<BEnd>>(surface);
 
         on_commit_buffer_handler(surface);
         self.backend_data.early_import(surface);


### PR DESCRIPTION
* Extra relative motion event functions `impl`'d -- basically, but compiles for now. Hopefully fixes #65. 
* Hopefully pinned `smithay` dependency to today's most recent commit (`0673cc13`) 