### PR TITLE
FIX: Resizing from Top/Left Sides now behaves nicely.

### DIFF
--- a/src/compositor/shell/mod.rs
+++ b/src/compositor/shell/mod.rs
@@ -29,6 +29,7 @@ use smithay::{
 };
 
 pub use self::avwindow::{AvWindow, AvWindowRenderElement};
+pub use self::grabs::handle_commit;
 use self::grabs::ResizeState;
 
 use super::{
@@ -112,6 +113,7 @@ impl<BEnd: Backend> CompositorHandler for Navda<BEnd> {
             }
         }
         self.popups.commit(surface);
+        handle_commit(&mut self.space, surface);
 
         ensure_initial_configure(surface, &self.space, &mut self.popups)
     }


### PR DESCRIPTION
Before, when resizing from top/left edge/corners, the window would not stay in one place and end up a buggy mess.

Now, I've 'borrowed' code from `smallvil` and spliced it into our `anvil` codebase, and it works!

This will solve #63 