### PR TITLE
Devcontainer: Support winit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
     },
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
       "upgradePackages": true,
-      "packages": "pkg-config build-essential libudev-dev libwayland-dev libseat-dev libsystemd-dev neofetch"
+      "packages": "pkg-config build-essential libudev-dev libwayland-dev libseat-dev libsystemd-dev libxkbcommon-dev libinput-dev libgbm-dev xauth x11-utils x11-xserver-utils libxrandr-dev libxi-dev libx11-xcb1 libx11-dev libegl1-mesa xwayland neofetch"
     },
     "ghcr.io/dhoeric/features/act:1": {}
   },
@@ -32,13 +32,16 @@
   "customizations": {
     "vscode": {
       "extensions": [
-		"rust-lang.rust-analyzer",
-		"serayuzgur.crates",
-		"tamasfe.even-better-toml",
-		"vadimcn.vscode-lldb",
-		"ms-vsliveshare.vsliveshare",
-		"GitHub.vscode-pull-request-github"
-	]
+        "rust-lang.rust-analyzer",
+        "serayuzgur.crates",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb",
+        "ms-vsliveshare.vsliveshare",
+        "GitHub.vscode-pull-request-github",
+        "formulahendry.code-runner",
+        "streetsidesoftware.code-spell-checker",
+        "huibizhang.codesnap-plus"
+      ]
     }
   },
 
@@ -46,5 +49,9 @@
   // "customizations": {},
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  "remoteUser": "root"
+  "remoteUser": "root",
+  "runArgs": [
+    "--privileged",
+    "--network=host"
+  ]
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -7,5 +7,5 @@ export XDG_RUNTIME_DIR=/run/user/$(id -u)\n\
 export DISPLAY=host.docker.internal:0
 " >> ~/.zshrc;
 su - root -c "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly"
-mkdir -p /run/user/$(id -u)                                                                                               14:30:49 
+mkdir -p /run/user/$(id -u)
 chmod 0700 /run/user/$(id -u)

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,7 +1,11 @@
 git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ~/.oh-my-zsh/themes/powerlevel10k;
 sed -i 's/devcontainers/powerlevel10k\/powerlevel10k/g' ~/.zshrc;
 echo "\
-source /workspaces/Compositor/.devcontainer/pl10k.zsh \n\
-export PKG_CONFIG_PATH=\"/usr/lib/aarch64-linux-gnu/pkgconfig\"\
+source /workspaces/Compositor/.devcontainer/pl10k.zsh\n\
+export PKG_CONFIG_PATH=\"/usr/lib/$(ls /usr/lib/|grep "linux-gnu")/pkgconfig\"\n\
+export XDG_RUNTIME_DIR=/run/user/$(id -u)\n\
+export DISPLAY=host.docker.internal:0
 " >> ~/.zshrc;
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+su - root -c "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly"
+mkdir -p /run/user/$(id -u)                                                                                               14:30:49 
+chmod 0700 /run/user/$(id -u)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,26 +1,30 @@
 {
-    "cSpell.words": [
-        "alacritty",
-        "Avdan",
-        "avdanos",
-        "avkeys",
-        "avmacro",
-        "avvalue",
-        "Calloop",
-        "cannonize",
-        "consts",
-        "deez",
-        "Fullscreen",
-        "Hasher",
-        "Indentable",
-        "keybinds",
-        "Nadva",
-        "Navda",
-        "Renderbuffer",
-        "smithay",
-        "stdlog",
-        "templating",
-        "winit",
-        "xwayland"
-    ]
+  "cSpell.words": [
+    "alacritty",
+    "Avdan",
+    "avdanos",
+    "avkeys",
+    "avmacro",
+    "avvalue",
+    "Calloop",
+    "cannonize",
+    "consts",
+    "deez",
+    "Fullscreen",
+    "Hasher",
+    "Indentable",
+    "keybinds",
+    "Nadva",
+    "Navda",
+    "Renderbuffer",
+    "smithay",
+    "stdlog",
+    "templating",
+    "winit",
+    "xwayland"
+  ],
+  "code-runner.executorMapByGlob": {
+    "*": "cd $dir && cargo run"
+  },
+  "code-runner.runInTerminal": true
 }

--- a/Devcontainer.md
+++ b/Devcontainer.md
@@ -1,0 +1,66 @@
+# Using devcontainer
+
+## Prerequisites
+
+To use devcontainer, you need the following:
+
+- Docker
+- VSCode
+
+In addition, you will need a xserver to display the compositor.
+
+**MacOS**
+
+You need XQuartz:
+
+```sh
+brew install --cask xquartz
+```
+
+and you need to allow docker to access XQuartz by
+
+1. Open XQuartz
+2. Open settings \(through menubar or `cmd`+`,`)
+3. Go to security
+4. Enable `Allow connections from network clients`
+
+**Windows**
+
+Hi, Frox here. I don't use Windows, so I would really appreciate if someone can help me with this part of the guide.
+
+**Linux**
+
+You probably already have xhost, so run the following command to allow docker to access xhost:
+
+```sh
+xhost +local:
+```
+
+If xhost is not found, you need to install it:
+
+**Ubuntu and Debian**:
+
+```sh
+sudo apt-get install x11-xserver-utils
+```
+
+**CentOS and Fedora**:
+
+```sh
+sudo dnf install xorg-x11-xauth
+```
+
+**Arch Linux**:
+
+```sh
+sudo pacman -S xorg-xhost
+```
+
+## Running the devcontainer
+
+1. Open the compositor project in VSCode.
+2. Open command and search for `Dev Containers: Reopen in Container`
+3. Installation and configuration will start automatically
+4. Enjoy!
+
+Now if you want to run the compositor, running `cargo run` should in theory just run. That, however, may have some compatibility issues. Happy coding!

--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
 # Compositor
 
-This is a Wayland compositor written in Rust made using [Smithay](https://smithay.github.io/). 
+This is a Wayland compositor written in Rust made using [Smithay](https://smithay.github.io/).
 
 Currently, it is heavily based off Smithay's `anvil` reference compositor.
 
 ## Features
+
 - [ ] Backends
-    - [ ] winit
-    - [x] udev
+  - [ ] winit
+  - [x] udev
 - [ ] Window Decorations
 - [ ] Abstractions over Wayland Stack
 - [ ] Integration with GUI Shell components
-- [ ] API 
+- [ ] API
 
 ## Contributing
 
 Please see the [contributing guidelines](https://github.com/Avdan-OS/Compositor/blob/main/CONTRIBUTING.md) for more information.
+
+## Devcontainer
+
+If you want to look into developing in devcontainer, please click [here](./devcontainer.md)


### PR DESCRIPTION
Just some DX update

- Update dependencies list for devcontainer
- Add additional scripts and perms to allow winit xwayland + xhost
- Documentation for using devcontainer
- Code Runner!

Yes, you can now run compositor without VM:

![Screenshot_2023-04-05_at_7 28 10_AM](https://user-images.githubusercontent.com/51555391/229945215-29d6f3e7-be08-45d0-80ae-c8d9197e99a2.png)

![vibe](https://user-images.githubusercontent.com/51555391/176177206-ec3f9dce-8780-4fe8-b6ac-5eeeac2038d4.gif)